### PR TITLE
Postgres 9.5 api updates

### DIFF
--- a/backend/compose.yml
+++ b/backend/compose.yml
@@ -20,7 +20,7 @@ services:
     command: sh -c "/set-timezone.sh && /start.sh"
 
   postgis:
-    image: kartoza/postgis:9.4-2.1
+    image: kartoza/postgis:9.5-2.2
     volumes:
       - ~/postgres_data/smartercleanup-api:/var/lib/postgresql
       - ./start-postgis.sh:/start-postgis.sh
@@ -31,8 +31,9 @@ services:
       - POSTGRES_PASS=${POSTGRES_PASS}
       - POSTGRES_USER=${POSTGRES_USER}
       - TZ=${TZ}
+      - ALLOW_IP_RANGE=${POSTGRES_ALLOW_IP_RANGE}
     restart: always
-    command: sh -c "/set-timezone.sh && echo \"host all all 0.0.0.0/0 md5\" >> /etc/postgresql/9.4/main/pg_hba.conf && /start-postgis.sh"
+    command: sh -c "/set-timezone.sh && /start-postgis.sh"
 
   smartercleanup-api:
     image: smartercleanup/api:release-0.6.3

--- a/backend/set-timezone.sh
+++ b/backend/set-timezone.sh
@@ -8,6 +8,7 @@ mkdir -p /config/etc && mv /etc/timezone /config/etc/ && ln -s /config/etc/timez
 dpkg-reconfigure -f noninteractive tzdata
 # Set the time zone
 echo "$TZ" > /config/etc/timezone
-echo "updated datetime is:"
+echo "Updated datetime is:"
 date
+echo ""
 


### PR DESCRIPTION
**don't merge**

adds latest postgis

currently blocked, however, because we are unable to restore our binary backup file due to the postgis 2.1 -> 2.2 upgrade. Perhaps we need a cleaner binary backup?

But below is our attempt when restoring from a clean sql backup via `pg_dump -h localhost -W -U postgres --clean -f test.dump shareabouts_v2`. This seems to be an issue with our api, and on the master branch, because it happens regardless of our postgres version:

`>psql -U postgres --single-transaction --set ON_ERROR_STOP=on shareabouts_v2 < test.dump`

```
root@3b988dd53d1f:/api/src# psql -h postgis -p 5432 -U postgres --single-transaction --set ON_ERROR_STOP=on shareabouts_v2 < /dbname.dump
Password for user postgres:
SET
SET
SET
SET
SET
SET
SET
ALTER TABLE
ALTER TABLE
ALTER TABLE
ALTER TABLE
ALTER TABLE
ALTER TABLE
ALTER TABLE
ALTER TABLE
ALTER TABLE
ALTER TABLE
ALTER TABLE
ALTER TABLE
ALTER TABLE
ALTER TABLE
ALTER TABLE
ALTER TABLE
ALTER TABLE
ALTER TABLE
ALTER TABLE
ALTER TABLE
ALTER TABLE
ALTER TABLE
ALTER TABLE
ALTER TABLE
ERROR:  constraint "djkombu_message_queue_id_fkey" of relation "djkombu_message" does not exist
```