### PR TITLE
ensure secure login traffic is interpreted correctly by Django

### DIFF
--- a/backend/nginx.conf
+++ b/backend/nginx.conf
@@ -67,7 +67,11 @@ http {
             root /api;
             try_files $uri $uri/;
         }
+
         location / {
+            proxy_redirect off;
+            proxy_set_header X-Forwarded-Proto https;
+            proxy_set_header X-Forwarded-Host $host;
             proxy_pass http://smartercleanup-api:8010;
         }
     }


### PR DESCRIPTION
Addresses: https://github.com/mapseed/platform/issues/394

**NOTE**: this PR works in conjunction with https://github.com/mapseed/api/pull/101.

This PR ensures that api traffic is proxied correctly to Django, such that Django can build the correct `Location` header in the response to sign-in requests.

We use two headers to accomplish this: `X-Forwarded-Proto` to set the protocol, and `X-Forwarded-Host` to set the original host.